### PR TITLE
FIX: Set containment flag of root container reference

### DIFF
--- a/src/main/java/eme/generator/EMemberGenerator.java
+++ b/src/main/java/eme/generator/EMemberGenerator.java
@@ -81,6 +81,7 @@ public class EMemberGenerator {
         reference.setName("containedElements");
         reference.setUpperBound(-1); // one to many relation
         reference.setEType(EcorePackage.eINSTANCE.getEObject());
+        reference.setContainment(true);
         rootContainer.getEStructuralFeatures().add(reference);
     }
 


### PR DESCRIPTION
This PR adds the setting of the containment flag for the container reference in the artificially created root container. This is necessary to fulfill its purpose to contain all model elements. 