### PR TITLE
Support multiple selections: execute the plugin on several projects simultaneously 

### DIFF
--- a/src/main/java/eme/handlers/ProjectHandler.java
+++ b/src/main/java/eme/handlers/ProjectHandler.java
@@ -15,73 +15,80 @@ import eme.properties.ExtractionProperties;
 
 /**
  * Handler for the Ecore metamodel extraction of specific project.
+ * 
  * @author Timur Saglam
  */
 public class ProjectHandler extends MainHandler {
 
-    /**
-     * Base constructor.
-     */
-    public ProjectHandler() {
-        super();
-    }
+	/**
+	 * Base constructor.
+	 */
+	public ProjectHandler() {
+		super();
+	}
 
-    /**
-     * Constructor that sets the title.
-     * @param title is the title.
-     */
-    public ProjectHandler(String title) {
-        super(title);
-    }
+	/**
+	 * Constructor that sets the title.
+	 * 
+	 * @param title is the title.
+	 */
+	public ProjectHandler(String title) {
+		super(title);
+	}
 
-    /**
-     * Accesses the project form the selection and starts the extraction.
-     */
-    @Override
-    public Object execute(ExecutionEvent event) throws ExecutionException {
-        ISelection selection = HandlerUtil.getActiveWorkbenchWindow(event).getActivePage().getSelection();
-        if (selection instanceof IStructuredSelection) {
-            Object element = ((IStructuredSelection) selection).getFirstElement();
-            if (element instanceof IProject) {
-                IProject project = (IProject) element;
-                if (isJavaProject(project)) {
-                    startExtraction((IProject) element);
-                } else {
-                    projectMessage(event);
-                }
-            } else if (element instanceof IJavaProject) {
-                startExtraction(((IJavaProject) element).getProject());
-            } else {
-                throw new IllegalStateException("Invalid selection: " + element + " is not a project.");
-            }
-        }
-        return null;
-    }
+	/**
+	 * Accesses the project form the selection and starts the extraction.
+	 */
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		ISelection selection = HandlerUtil.getActiveWorkbenchWindow(event).getActivePage().getSelection();
+		if (selection instanceof IStructuredSelection) {
+			for (Object element : (IStructuredSelection) selection) {
+				if (element instanceof IProject) {
+					IProject project = (IProject) element;
+					if (isJavaProject(project)) {
+						startExtraction((IProject) element);
+					} else {
+						projectMessage(event);
+					}
+				} else if (element instanceof IJavaProject) {
+					startExtraction(((IJavaProject) element).getProject());
+				} else {
+					throw new IllegalStateException("Invalid selection: " + element + " is not a project.");
+				}
+			}
+		}
+		return null;
+	}
 
-    /**
-     * Warning message in case of a non-Java project.
-     */
-    private void projectMessage(ExecutionEvent event) throws ExecutionException {
-        String message = "This project is not a Java project. Therefore, a metamodel cannot be extracted.";
-        IWorkbenchWindow window = HandlerUtil.getActiveWorkbenchWindowChecked(event);
-        MessageDialog.openInformation(window.getShell(), title, message);
-    }
+	/**
+	 * Warning message in case of a non-Java project.
+	 */
+	private void projectMessage(ExecutionEvent event) throws ExecutionException {
+		String message = "This project is not a Java project. Therefore, a metamodel cannot be extracted.";
+		IWorkbenchWindow window = HandlerUtil.getActiveWorkbenchWindowChecked(event);
+		MessageDialog.openInformation(window.getShell(), title, message);
+	}
 
-    /**
-     * Allows the configuration of the {@link ExtractionProperties} of the {@link EcoreMetamodelExtraction}.
-     * @param properties are the {@link ExtractionProperties}.
-     */
-    protected void configure(ExtractionProperties properties) {
-        // Default: do nothing, use default properties.
-    }
+	/**
+	 * Allows the configuration of the {@link ExtractionProperties} of the
+	 * {@link EcoreMetamodelExtraction}.
+	 * 
+	 * @param properties are the {@link ExtractionProperties}.
+	 */
+	protected void configure(ExtractionProperties properties) {
+		// Default: do nothing, use default properties.
+	}
 
-    /**
-     * Starts the extraction by calling an extraction method from the class {@link EcoreMetamodelExtraction}.
-     * @param project is the parameter for the methods that is called.
-     */
-    protected void startExtraction(IProject project) {
-        EcoreMetamodelExtraction extraction = new EcoreMetamodelExtraction(); // EME instance
-        configure(extraction.getProperties()); // configure extraction
-        extraction.extract(project); // start
-    }
+	/**
+	 * Starts the extraction by calling an extraction method from the class
+	 * {@link EcoreMetamodelExtraction}.
+	 * 
+	 * @param project is the parameter for the methods that is called.
+	 */
+	protected void startExtraction(IProject project) {
+		EcoreMetamodelExtraction extraction = new EcoreMetamodelExtraction(); // EME instance
+		configure(extraction.getProperties()); // configure extraction
+		extraction.extract(project); // start
+	}
 }

--- a/src/main/java/eme/ui/SelectionWindow.java
+++ b/src/main/java/eme/ui/SelectionWindow.java
@@ -68,7 +68,7 @@ public class SelectionWindow { // TODO (HIGH) enable all packages of a type when
         shell = new Shell();
         shell.setMinimumSize(new Point(MIN_WIDTH, MIN_HEIGHT));
         shell.setSize(WIDTH, HEIGHT);
-        shell.setText("Select extraction scope");
+        shell.setText("Select extraction scope for project: " + model.getProjectName());
         shell.setLayout(new FillLayout(SWT.HORIZONTAL));
         // Tree viewer:
         CheckboxTreeViewer treeViewer = new CheckboxTreeViewer(shell, SWT.BORDER);


### PR DESCRIPTION
This PR adds support for multiple selections.
It allows the plugin to be executed on multiple projects simultaneously instead of going through them one by one.